### PR TITLE
Integrate Package-Based Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,20 @@ github_token =
 gitlab_token =
 ; Bitbucket
 bitbucket_username =
-bitbucket_password =" > ~/.producer/config
+bitbucket_password =
+
+[commands]
+; the command to use for running tests, defaults to global install
+tests = phpunit
+; the command to use for generating docs, defaults to global install
+docs = phpdoc -d src/ -t {$target} --force --verbose --template=xml
+
+[files]
+changes = CHANGES.md
+license = LICENSE.md
+tests = phpunit.xml.dist
+readme = README.MD
+contributing = CONTRIBUTING.md" > ~/.producer/config
 ```
 
 You can then edit `~/.producer/config` to enter your access credentials, any or all of:
@@ -60,6 +73,12 @@ You can then edit `~/.producer/config` to enter your access credentials, any or 
 - Bitbucket username and password.
 
 > WARNING: Saving your username and password for Bitbucket in plain text is not very secure. Bitbucket doesn't have personal API tokens, so it's either "username and password" or bring in an external OAuth1 library with all its dependencies just to authenticate to Bitbucket. The latter option might show up in a subsequent release.
+
+### Package Configuration
+
+Inside your package, you may define a `.producer/config` file that overrides any of these options for that specific package.
+You may also add to the `[files]` list to ensure other files are present and not empty. Lastly, not that
+in the `docs` command, you may use `{$target}` to note the output path for that command.
 
 ## Getting Started
 

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -9,6 +9,7 @@
 namespace Producer\Command;
 
 use Producer\Api\ApiInterface;
+use Producer\Config;
 use Producer\Repo\RepoInterface;
 use Psr\Log\LoggerInterface;
 
@@ -50,6 +51,15 @@ abstract class AbstractCommand implements CommandInterface
 
     /**
      *
+     * The producer configuration
+     * 
+     * @var Config
+     *
+     */
+    protected $config;
+
+    /**
+     *
      * Constructor.
      *
      * @param LoggerInterface $logger The logger.
@@ -57,16 +67,20 @@ abstract class AbstractCommand implements CommandInterface
      * @param RepoInterface $repo The local repository.
      *
      * @param ApiInterface $api The remote API.
-     *
+     * 
+     * @param Config $config The global and project configuration.
+     * 
      */
     public function __construct(
         LoggerInterface $logger,
         RepoInterface $repo,
-        ApiInterface $api
+        ApiInterface $api,
+        Config $config
     ) {
         $this->logger = $logger;
         $this->repo = $repo;
         $this->api = $api;
+        $this->config = $config;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,31 +24,7 @@ class Config
      * @var array
      *
      */
-    protected $data = [
-        'markdown_files' => [
-            'CHANGES',
-            'CONTRIBUTING',
-            'LICENSE',
-            'README',
-        ],
-
-        'required_files' => [
-            'phpunit.xml.dist',
-        ],
-
-        'license_file' => [
-            'LICENSE', 'LICENSE.md'
-        ]
-    ];
-
-    /**
-     *
-     * Config items that are CSV and need to be arrays
-     *
-     * @var array
-     *
-     */
-    protected $csv_items = ['markdown_files', 'required_files'];
+    protected $data = [];
 
     /**
      *
@@ -57,7 +33,7 @@ class Config
      * @var string
      *
      */
-    protected $global_file = '.producer/config';
+    protected $global_config_file = '.producer/config';
 
     /**
      *
@@ -66,7 +42,7 @@ class Config
      * @var string
      *
      */
-    protected $project_file = '.producer';
+    protected $package_config_file = '.producer/config';
 
     /**
      *
@@ -82,8 +58,7 @@ class Config
     public function __construct(Fsio $homefs, Fsio $repofs)
     {
         $this->loadGlobalConfig($homefs);
-        $this->loadProjectConfig($repofs);
-        $this->parseCsvToArrays();
+        $this->loadPackageConfig($repofs);
     }
 
     /**
@@ -97,12 +72,12 @@ class Config
      */
     protected function loadGlobalConfig(Fsio $fsio)
     {
-        if (! $fsio->isFile($this->global_file)) {
-            $path = $fsio->path($this->global_file);
+        if (! $fsio->isFile($this->global_config_file)) {
+            $path = $fsio->path($this->global_config_file);
             throw new Exception("Config file {$path} not found.");
         }
 
-        $this->data = array_merge($this->data, $fsio->parseIni($this->global_file));
+        $this->data = array_merge($this->data, $fsio->parseIni($this->global_config_file, true));
     }
     
     /**
@@ -113,10 +88,10 @@ class Config
      * @throws Exception
      *
      */
-    public function loadProjectConfig(Fsio $fsio)
+    public function loadPackageConfig(Fsio $fsio)
     {
-        if ($fsio->isFile($this->project_file)) {
-            $config = $fsio->parseIni($this->project_file);
+        if ($fsio->isFile($this->package_config_file)) {
+            $config = $fsio->parseIni($this->package_config_file, true);
             $this->data = array_merge($this->data, $config);
         }
     }
@@ -136,7 +111,7 @@ class Config
             return $this->data[$key];
         }
 
-        throw new Exception("No value set for '$key' in '{$this->file}'.");
+        throw new Exception("No value set for '$key' in '{$this->global_config_file}' or '{$this->package_config_file}'.");
     }
 
     /**
@@ -162,19 +137,5 @@ class Config
     public function getAll()
     {
         return $this->data ?: [];
-    }
-
-    /**
-     *
-     * Parses desired CSV config items into array
-     *
-     */
-    protected function parseCsvToArrays()
-    {
-        foreach ($this->csv_items as $item) {
-            if (is_string($this->data[$item])) {
-                $this->data[$item] = explode(",", trim($this->data[$item]));
-            }
-        }
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -19,12 +19,36 @@ class Config
 {
     /**
      *
-     * The config values.
+     * The config values with defaults.
      *
      * @var array
      *
      */
-    protected $data = [];
+    protected $data = [
+        'markdown_files' => [
+            'CHANGES',
+            'CONTRIBUTING',
+            'LICENSE',
+            'README',
+        ],
+
+        'required_files' => [
+            'phpunit.xml.dist',
+        ],
+
+        'license_file' => [
+            'LICENSE', 'LICENSE.md'
+        ]
+    ];
+
+    /**
+     *
+     * Config items that are CSV and need to be arrays
+     *
+     * @var array
+     *
+     */
+    protected $csv_items = ['markdown_files', 'required_files'];
 
     /**
      *
@@ -59,6 +83,7 @@ class Config
     {
         $this->loadGlobalConfig($homefs);
         $this->loadProjectConfig($repofs);
+        $this->parseCsvToArrays();
     }
 
     /**
@@ -77,7 +102,7 @@ class Config
             throw new Exception("Config file {$path} not found.");
         }
 
-        $this->data = $fsio->parseIni($this->global_file);
+        $this->data = array_merge($this->data, $fsio->parseIni($this->global_file));
     }
     
     /**
@@ -93,7 +118,6 @@ class Config
         if ($fsio->isFile($this->project_file)) {
             $config = $fsio->parseIni($this->project_file);
             $this->data = array_merge($this->data, $config);
-        } else {
         }
     }
 
@@ -138,5 +162,19 @@ class Config
     public function getAll()
     {
         return $this->data ?: [];
+    }
+
+    /**
+     *
+     * Parses desired CSV config items into array
+     *
+     */
+    protected function parseCsvToArrays()
+    {
+        foreach ($this->csv_items as $item) {
+            if (is_string($this->data[$item])) {
+                $this->data[$item] = explode(",", trim($this->data[$item]));
+            }
+        }
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -28,28 +28,73 @@ class Config
 
     /**
      *
-     * The name of the Producer config file.
+     * The name of the global Producer config file.
      *
      * @var string
      *
      */
-    protected $file = '.producer/config';
+    protected $global_file = '.producer/config';
+
+    /**
+     *
+     * The name of the project's config file
+     *
+     * @var string
+     *
+     */
+    protected $project_file = '.producer';
 
     /**
      *
      * Constructor.
      *
-     * @param Fsio $fsio A filesystem I/O object.
+     * @param Fsio $homefs
+     *
+     * @param Fsio $repofs
+     *
+     * @throws Exception
      *
      */
-    public function __construct(Fsio $fsio)
+    public function __construct(Fsio $homefs, Fsio $repofs)
     {
-        if (! $fsio->isFile($this->file)) {
-            $path = $fsio->path($this->file);
+        $this->loadGlobalConfig($homefs);
+        $this->loadProjectConfig($repofs);
+    }
+
+    /**
+     * 
+     * Load's Producer's global config file
+     * 
+     * @param Fsio $fsio
+     *
+     * @throws Exception
+     *
+     */
+    protected function loadGlobalConfig(Fsio $fsio)
+    {
+        if (! $fsio->isFile($this->global_file)) {
+            $path = $fsio->path($this->global_file);
             throw new Exception("Config file {$path} not found.");
         }
 
-        $this->data = $fsio->parseIni($this->file);
+        $this->data = $fsio->parseIni($this->global_file);
+    }
+    
+    /**
+     * Loads the project's config file, if it exists
+     * 
+     * @param Fsio $fsio
+     *
+     * @throws Exception
+     *
+     */
+    public function loadProjectConfig(Fsio $fsio)
+    {
+        if ($fsio->isFile($this->project_file)) {
+            $config = $fsio->parseIni($this->project_file);
+            $this->data = array_merge($this->data, $config);
+        } else {
+        }
     }
 
     /**
@@ -68,5 +113,30 @@ class Config
         }
 
         throw new Exception("No value set for '$key' in '{$this->file}'.");
+    }
+
+    /**
+     *
+     * Confirm that a config value is set
+     *
+     * @param $key
+     *
+     * @return bool
+     *
+     */
+    public function has($key) {
+        return (isset($this->data[$key]));
+    }
+
+    /**
+     *
+     * Return all configuration data
+     *
+     * @return array
+     *
+     */
+    public function getAll()
+    {
+        return $this->data ?: [];
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -77,7 +77,7 @@ class Config
             throw new Exception("Config file {$path} not found.");
         }
 
-        $this->data = array_merge($this->data, $fsio->parseIni($this->global_config_file, true));
+        $this->data = $fsio->parseIni($this->global_config_file, true);
     }
     
     /**
@@ -92,7 +92,8 @@ class Config
     {
         if ($fsio->isFile($this->package_config_file)) {
             $config = $fsio->parseIni($this->package_config_file, true);
-            $this->data = array_merge($this->data, $config);
+            $this->data = array_replace_recursive($this->data, $config);
+            echo "here";
         }
     }
 

--- a/src/Repo/AbstractRepo.php
+++ b/src/Repo/AbstractRepo.php
@@ -8,6 +8,7 @@
  */
 namespace Producer\Repo;
 
+use Producer\Config;
 use Producer\Exception;
 use Producer\Fsio;
 use Psr\Log\LoggerInterface;
@@ -37,7 +38,7 @@ abstract class AbstractRepo implements RepoInterface
      * @var array
      *
      */
-    protected $configData = [];
+    protected $vcsConfig = [];
 
     /**
      *
@@ -68,18 +69,30 @@ abstract class AbstractRepo implements RepoInterface
 
     /**
      *
+     * Global and project configuration.
+     *
+     * @var Config
+     *
+     */
+    protected $producerConfig;
+
+    /**
+     *
      * Constructor.
      *
      * @param Fsio $fsio A filesystem I/O object.
      *
      * @param LoggerInterface $logger A logger.
      *
+     * @param Config $config
+     *
      */
-    public function __construct(Fsio $fsio, LoggerInterface $logger)
+    public function __construct(Fsio $fsio, LoggerInterface $logger, Config $config)
     {
         $this->fsio = $fsio;
         $this->logger = $logger;
-        $this->configData = $this->fsio->parseIni($this->configFile, true);
+        $this->vcsConfig = $this->fsio->parseIni($this->configFile, true);
+        $this->producerConfig = $config;
     }
 
     /**

--- a/src/Repo/AbstractRepo.php
+++ b/src/Repo/AbstractRepo.php
@@ -220,8 +220,15 @@ abstract class AbstractRepo implements RepoInterface
     public function checkTests()
     {
         $this->shell('composer update');
-        $phpunit = $this->which('phpunit');
-        $last = $this->shell($phpunit, $output, $return);
+
+        // Issue: #4 - Allow users to define test commands
+        if ($this->producerConfig->has('test_command')) {
+            $command = $this->producerConfig->get('test_command');
+        } else {
+            $command = $this->which('phpunit');
+        }
+
+        $last = $this->shell($command, $output, $return);
         if ($return) {
             throw new Exception($last);
         }

--- a/src/Repo/AbstractRepo.php
+++ b/src/Repo/AbstractRepo.php
@@ -168,13 +168,7 @@ abstract class AbstractRepo implements RepoInterface
      */
     public function checkSupportFiles()
     {
-        $files = [
-            'CHANGES',
-            'CONTRIBUTING',
-            'LICENSE',
-            'README',
-        ];
-        foreach ($files as $file) {
+        foreach ($this->producerConfig->get('markdown_files') as $file) {
             $found = $this->fsio->isFile($file, "{$file}.md");
             if (! $found) {
                 throw new Exception("{$file} file is missing.");
@@ -183,11 +177,8 @@ abstract class AbstractRepo implements RepoInterface
                 throw new Exception("{$found} file is empty.");
             }
         }
-
-        $files = [
-            'phpunit.xml.dist',
-        ];
-        foreach ($files as $file) {
+        
+        foreach ($this->producerConfig->get('required_files') as $file) {
             if (! $this->fsio->isFile($file)) {
                 throw new Exception("{$file} file is missing.");
             }
@@ -204,7 +195,7 @@ abstract class AbstractRepo implements RepoInterface
      */
     public function checkLicenseYear()
     {
-        $file = $this->fsio->isFile('LICENSE', 'LICENSE.md');
+        $file = call_user_func_array([$this->fsio, 'isFile'], $this->producerConfig->get('license_file'));
         $license = $this->fsio->get($file);
         $year = date('Y');
         if (strpos($license, $year) === false) {

--- a/src/Repo/Git.php
+++ b/src/Repo/Git.php
@@ -37,10 +37,10 @@ class Git extends AbstractRepo
      */
     public function getOrigin()
     {
-        if (! isset($this->configData['remote origin']['url'])) {
+        if (! isset($this->vcsConfig['remote origin']['url'])) {
             throw new Exception('Could not determine remote origin.');
         }
-        return $this->configData['remote origin']['url'];
+        return $this->vcsConfig['remote origin']['url'];
     }
 
     /**

--- a/src/Repo/Hg.php
+++ b/src/Repo/Hg.php
@@ -39,10 +39,10 @@ class Hg extends AbstractRepo
      */
     public function getOrigin()
     {
-        if (! isset($this->configData['paths']['default'])) {
+        if (! isset($this->vcsConfig['paths']['default'])) {
             throw new Exception('Could not determine default path.');
         }
-        return $this->configData['paths']['default'];
+        return $this->vcsConfig['paths']['default'];
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace Producer;
+
+class ConfigTest extends \PHPUnit_Framework_TestCase
+{
+    protected function makeFsio(array $returnData, $isFile = true)
+    {
+        $fsio = $this->getMockBuilder(Fsio::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['isFile', 'parseIni'])
+            ->getMock();
+        $fsio
+            ->expects($this->any())
+            ->method('isFile')->will($this->returnValue($isFile));
+        $fsio
+            ->expects($this->any())
+            ->method('parseIni')->will($this->returnValue($returnData));
+
+        return $fsio;
+    }
+
+    /* Tests */
+    public function test_it_does_not_load_a_missing_project_config_file()
+    {
+        $home = $this->makeFsio(['one' => 1, 'two' => 'two']);
+        $repo = $this->makeFsio([], false);
+
+        $config = new Config($home, $repo);
+
+        $this->assertEquals([
+            'one' => 1,
+            'two' => 'two',
+        ], $config->getAll(), "failed to append project configuration");
+    }
+
+    public function test_it_appends_project_config_items()
+    {
+        $home = $this->makeFsio(['one' => 1, 'two' => 'two']);
+        $repo = $this->makeFsio(['three' => 3, 'four' => 'four']);
+
+        $config = new Config($home, $repo);
+        
+        $this->assertEquals([
+            'one' => 1,
+            'two' => 'two',
+            'three' => 3,
+            'four' => 'four'
+        ], $config->getAll(), "failed to append project configuration");
+    }
+
+    public function test_it_overwrites_global_config()
+    {
+        $home = $this->makeFsio(['one' => 1, 'two' => 'two']);
+        $repo = $this->makeFsio(['one' => 'one', 'four' => 'four']);
+
+        $config = new Config($home, $repo);
+
+        $this->assertEquals([
+            'one' => 'one',
+            'two' => 'two',
+            'four' => 'four'
+        ], $config->getAll(), "failed to append project configuration");
+    }
+}
+

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -22,44 +22,50 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     /* Tests */
     public function test_it_does_not_load_a_missing_project_config_file()
     {
-        $home = $this->makeFsio(['one' => 1, 'two' => 'two']);
+        $home = $this->makeFsio(['one' => 1, 'two' => ['a' => 'a', 'b' => 'b']]);
         $repo = $this->makeFsio([], false);
 
         $config = new Config($home, $repo);
 
         $this->assertEquals([
             'one' => 1,
-            'two' => 'two',
+            'two' => [
+                'a' => 'a',
+                'b' => 'b'
+            ]
         ], $config->getAll(), "failed to append project configuration");
     }
 
     public function test_it_appends_project_config_items()
     {
-        $home = $this->makeFsio(['one' => 1, 'two' => 'two']);
-        $repo = $this->makeFsio(['three' => 3, 'four' => 'four']);
+        $home = $this->makeFsio(['one' => 1, 'two' => ['a' => 'a']]);
+        $repo = $this->makeFsio(['three' => 3, 'two' => ['b' => 'b']]);
 
         $config = new Config($home, $repo);
         
         $this->assertEquals([
             'one' => 1,
-            'two' => 'two',
+            'two' => [
+                'a' => 'a',
+                'b' => 'b'
+            ],
             'three' => 3,
-            'four' => 'four'
         ], $config->getAll(), "failed to append project configuration");
     }
 
     public function test_it_overwrites_global_config()
     {
-        $home = $this->makeFsio(['one' => 1, 'two' => 'two']);
-        $repo = $this->makeFsio(['one' => 'one', 'four' => 'four']);
+        $home = $this->makeFsio(['one' => 1, 'two' => ['a' => 'a']]);
+        $repo = $this->makeFsio(['one' => 'one', 'two' => ['a' => 'b']]);
 
         $config = new Config($home, $repo);
 
+        $actual = $config->getAll();
+
         $this->assertEquals([
             'one' => 'one',
-            'two' => 'two',
-            'four' => 'four'
-        ], $config->getAll(), "failed to append project configuration");
+            'two' => ['a' => 'b'],
+        ], $actual, "failed to overwrite project configuration");
     }
 }
 


### PR DESCRIPTION
This pull request does two things in two commits, both discussed at issue  #4.

The user may now create a `.producer` INI file in the root of their project. These configuration items will be appended to AND OVERWRITE the existing global configuration if present. This allows for future customization. The `Config` object is also passed into the `AbstractCommand` and `AbstractRepo`.

I also added a couple helper methods to `Config` like `has()` and `getAll()`.

The second addition is the use of a `test_command` item in that `.producer` file. This allows users to execute a custom test command (instead of phpunit) for things like vagrant or ssh.

My goal was to do this in as little code as possible (while still being clean and readable). I think I followed the code style and I docblocked everything. I also added a test. I didn't touch documentation.

Of course, I'm happy to modify, refactor, or document anything here.
