### PR TITLE
Fix variable leaking from previous loop

### DIFF
--- a/src/Repo/AbstractRepo.php
+++ b/src/Repo/AbstractRepo.php
@@ -175,7 +175,8 @@ abstract class AbstractRepo implements RepoInterface
             'phpunit.xml.dist',
         ];
         foreach ($files as $file) {
-            if (! $this->fsio->isFile($file)) {
+            $found = $this->fsio->isFile($file);
+            if (! $found) {
                 throw new Exception("{$file} file is missing.");
             }
             if (trim($this->fsio->get($found)) === '') {


### PR DESCRIPTION
When checking for supported files, the variable `$found` is never updated in the second loop, which means the value can leak from the last entry of the previous loop
