### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/src/Api/Github.php
+++ b/src/Api/Github.php
@@ -26,15 +26,16 @@ class Github extends AbstractApi
      *
      * @param string $origin The repository remote origin.
      *
-     * @param string $user The API username.
+     * @param string $hostname The hostname of GitHub service.
      *
-     * @param string $token The API secret token.
+     * @param string $user   The API username.
      *
+     * @param string $token  The API secret token.
      */
-    public function __construct($origin, $user, $token)
+    public function __construct($origin, $hostname, $user, $token)
     {
         // set the HTTP object
-        $this->setHttp("https://{$user}:{$token}@api.github.com");
+        $this->setHttp("https://{$user}:{$token}@{$hostname}");
 
         // start by presuming HTTPS
         $repoName = parse_url($origin, PHP_URL_PATH);

--- a/src/Api/Github.php
+++ b/src/Api/Github.php
@@ -47,10 +47,14 @@ class Github extends AbstractApi
 
     private function setRepoNameFromOrigin($origin)
     {
+        // If SSH, strip username off so that `parse_url`
+        // can work as expected
+        if (strpos($origin, 'git@') !== false) {
+            $origin = substr($origin, 4);
+        }
+
         // start by presuming HTTPS
         $repoName = parse_url($origin, PHP_URL_PATH);
-
-        $repoName = explode(':', $repoName)[1];
 
         // strip .git from the end
         $repoName = preg_replace('/\.git$/', '', $repoName);

--- a/src/Api/Github.php
+++ b/src/Api/Github.php
@@ -51,7 +51,9 @@ class Github extends AbstractApi
         $repoName = parse_url($origin, PHP_URL_PATH);
 
         $repoName = explode(':', $repoName)[1];
-        $repoName = rtrim($repoName, '.git');
+
+        // strip .git from the end
+        $repoName = preg_replace('/\.git$/', '', $repoName);
 
         // retain
         $this->repoName = trim($repoName, '/');

--- a/src/Api/Github.php
+++ b/src/Api/Github.php
@@ -34,23 +34,24 @@ class Github extends AbstractApi
      */
     public function __construct($origin, $hostname, $user, $token)
     {
+        // @see https://developer.github.com/v3/enterprise
+        if (strpos($hostname, 'github.com') === false) {
+            $hostname .= '/api/v3';
+        }
+
         // set the HTTP object
         $this->setHttp("https://{$user}:{$token}@{$hostname}");
+        
+        $this->setRepoNameFromOrigin($origin);
+    }
 
+    private function setRepoNameFromOrigin($origin)
+    {
         // start by presuming HTTPS
         $repoName = parse_url($origin, PHP_URL_PATH);
 
-        // check for SSH
-        $ssh = 'git@github.com:';
-        $len = strlen($ssh);
-        if (substr($origin, 0, $len) == $ssh) {
-            $repoName = substr($origin, $len);
-        }
-
-        // strip .git from the end
-        if (substr($repoName, -4) == '.git') {
-            $repoName = substr($repoName, 0, -4);
-        }
+        $repoName = explode(':', $repoName)[1];
+        $repoName = rtrim($repoName, '.git');
 
         // retain
         $this->repoName = trim($repoName, '/');

--- a/src/Api/Gitlab.php
+++ b/src/Api/Gitlab.php
@@ -31,6 +31,15 @@ class Gitlab extends AbstractApi
 
     /**
      *
+     * The configured hostname for Gitlab
+     *
+     * @var string
+     *
+     */
+    protected $hostname;
+
+    /**
+     *
      * Constructor.
      *
      * @param string $origin The repository remote origin.
@@ -41,18 +50,23 @@ class Gitlab extends AbstractApi
     public function __construct($origin, $hostname, $token)
     {
         // set the HTTP object and token
-        $this->setHttp("https://{$hostname}/api/v3");
+        $this->setHttp("http://{$hostname}/api/v3");
         $this->token = $token;
+        $this->hostname = $hostname;
 
         $this->setRepoNameFromOrigin($origin);
     }
 
     private function setRepoNameFromOrigin($origin)
     {
+        // If SSH, strip username off so that `parse_url`
+        // can work as expected
+        if (strpos($origin, 'git@') !== false) {
+            $origin = substr($origin, 4);
+        }
+
         // start by presuming HTTPS
         $repoName = parse_url($origin, PHP_URL_PATH);
-
-        $repoName = explode(':', $repoName)[1];
 
         // strip .git from the end
         $repoName = preg_replace('/\.git$/', '', $repoName);

--- a/src/Api/Gitlab.php
+++ b/src/Api/Gitlab.php
@@ -50,7 +50,7 @@ class Gitlab extends AbstractApi
     public function __construct($origin, $hostname, $token)
     {
         // set the HTTP object and token
-        $this->setHttp("http://{$hostname}/api/v3");
+        $this->setHttp("https://{$hostname}/api/v3");
         $this->token = $token;
         $this->hostname = $hostname;
 

--- a/src/Api/Gitlab.php
+++ b/src/Api/Gitlab.php
@@ -35,29 +35,27 @@ class Gitlab extends AbstractApi
      *
      * @param string $origin The repository remote origin.
      *
-     * @param string $token The API secret token.
-     *
+     * @param string $hostname
+     * @param string $token  The API secret token.
      */
-    public function __construct($origin, $token)
+    public function __construct($origin, $hostname, $token)
     {
         // set the HTTP object and token
-        $this->setHttp("https://gitlab.com/api/v3");
+        $this->setHttp("https://{$hostname}/api/v3");
         $this->token = $token;
 
-        // presume HTTPS
+        $this->setRepoNameFromOrigin($origin);
+    }
+
+    private function setRepoNameFromOrigin($origin)
+    {
+        // start by presuming HTTPS
         $repoName = parse_url($origin, PHP_URL_PATH);
 
-        // check for SSH
-        $ssh = 'git@gitlab.com:';
-        $len = strlen($ssh);
-        if (substr($origin, 0, $len) == $ssh) {
-            $repoName = substr($origin, $len);
-        }
+        $repoName = explode(':', $repoName)[1];
 
         // strip .git from the end
-        if (substr($repoName, -4) == '.git') {
-            $repoName = substr($repoName, 0, -4);
-        }
+        $repoName = preg_replace('/\.git$/', '', $repoName);
 
         // retain
         $this->repoName = trim($repoName, '/');

--- a/src/Api/Gitlab.php
+++ b/src/Api/Gitlab.php
@@ -115,7 +115,7 @@ class Gitlab extends AbstractApi
             $issues[] = (object) [
                 'number' => $issue->iid,
                 'title' => $issue->title,
-                'url' => "https://gitlab.com/{$this->repoName}/issues/{$issue->iid}",
+                'url' => "https://{$this->hostname}/{$this->repoName}/issues/{$issue->iid}",
             ];
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -27,6 +27,7 @@ class Config
     protected $data = [
         'bitbucket_password' => null,
         'bitbucket_username' => null,
+        'github_baseurl' => 'https://api.github.com',
         'github_token' => null,
         'github_username' => null,
         'gitlab_token' => null,

--- a/src/Config.php
+++ b/src/Config.php
@@ -30,6 +30,7 @@ class Config
         'github_hostname' => 'api.github.com',
         'github_token' => null,
         'github_username' => null,
+        'gitlab_hostname' => 'gitlab.com',
         'gitlab_token' => null,
         'package' => '',
         'commands' => [

--- a/src/Config.php
+++ b/src/Config.php
@@ -27,7 +27,7 @@ class Config
     protected $data = [
         'bitbucket_password' => null,
         'bitbucket_username' => null,
-        'github_baseurl' => 'https://api.github.com',
+        'github_hostname' => 'api.github.com',
         'github_token' => null,
         'github_username' => null,
         'gitlab_token' => null,

--- a/src/ProducerContainer.php
+++ b/src/ProducerContainer.php
@@ -190,6 +190,7 @@ class ProducerContainer
             case ($this->isGitlabBased($origin, $config)):
                 return new Api\Gitlab(
                     $origin,
+                    $config->get('gitlab_hostname'),
                     $config->get('gitlab_token')
                 );
 
@@ -228,6 +229,10 @@ class ProducerContainer
 
     private function isGitlabBased($origin, $config)
     {
-        return strpos($origin, 'gitlab.com') !== false;
+        if ($config->get('gitlab_hostname') === 'gitlab.com') {
+            return strpos($origin, 'gitlab.com') !== false;
+        } else {
+            return strpos($origin, $config->get('gitlab_hostname')) !== false;
+        }
     }
 }

--- a/src/ProducerContainer.php
+++ b/src/ProducerContainer.php
@@ -182,6 +182,17 @@ class ProducerContainer
             case (strpos($origin, 'github.com') !== false):
                 return new Api\Github(
                     $origin,
+                    $config->get('github_baseurl'),
+                    $config->get('github_username'),
+                    $config->get('github_token')
+                );
+
+            // Default is github.com, so anything else in `github_baseurl`
+            // is assumed GitHub Enterprise
+            case (strpos($config->get('github_baseurl'), 'github.com') === false):
+                return new Api\Github(
+                    $origin,
+                    $config->get('github_baseurl'),
                     $config->get('github_username'),
                     $config->get('github_token')
                 );

--- a/src/ProducerContainer.php
+++ b/src/ProducerContainer.php
@@ -206,19 +206,24 @@ class ProducerContainer
         }
     }
 
+    /**
+     * Is GitHub-based if hostname is `api.github.com` and the project remote
+     * contains `github.com`. Alternatively, the project is using GitHub Enterprise
+     * if hostname is NOT `api.github.com` and the configured hostname matches
+     * the project remote called `origin`.
+     *
+     * @param $origin
+     * @param $config
+     *
+     * @return bool
+     */
     private function isGithubBased($origin, $config)
     {
-        // GitHub hostname is set to `api.github.com` and also appears
-        // in the current repository remote called origin.
-        $isGithubCom = $config->get('github_hostname') === 'api.github.com' &&
-            strpos($origin, 'github.com') !== false;
-
-        // GitHub hostname is set to something other than `api.github.com` and
-        // that same hostname appears in current repository remote called origin.
-        $isGithubEnterprise = $config->get('github_hostname') !== 'api.github.com' &&
-            strpos($origin, $config->get('github_hostname')) !== false;
-
-        return $isGithubCom || $isGithubEnterprise;
+        if ($config->get('github_hostname') === 'api.github.com') {
+            return strpos($origin, 'github.com') !== false;
+        } else {
+            return strpos($origin, $config->get('github_hostname')) !== false;
+        }
     }
 
     private function isGitlabBased($origin, $config)

--- a/src/ProducerContainer.php
+++ b/src/ProducerContainer.php
@@ -182,17 +182,17 @@ class ProducerContainer
             case (strpos($origin, 'github.com') !== false):
                 return new Api\Github(
                     $origin,
-                    $config->get('github_baseurl'),
+                    $config->get('github_hostname'),
                     $config->get('github_username'),
                     $config->get('github_token')
                 );
 
-            // Default is github.com, so anything else in `github_baseurl`
+            // Default is github.com, so anything else in `github_hostname`
             // is assumed GitHub Enterprise
-            case (strpos($config->get('github_baseurl'), 'github.com') === false):
+            case (strpos($config->get('github_hostname'), 'github.com') === false):
                 return new Api\Github(
                     $origin,
-                    $config->get('github_baseurl'),
+                    $config->get('github_hostname'),
                     $config->get('github_username'),
                     $config->get('github_token')
                 );

--- a/tests/Api/GitHubTest.php
+++ b/tests/Api/GitHubTest.php
@@ -1,0 +1,19 @@
+<?php
+namespace Producer;
+
+use Producer\Api\Github;
+
+class GitHubTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGitHubEnterprise()
+    {
+        $api = new Github(
+            'git@example.org:producerphp/producer.producer.git',
+            'example.org',
+            'username',
+            'token'
+        );
+
+        $this->assertEquals('producerphp/producer.producer', $api->getRepoName());
+    }
+}

--- a/tests/Api/GitHubTest.php
+++ b/tests/Api/GitHubTest.php
@@ -5,7 +5,19 @@ use Producer\Api\Github;
 
 class GitHubTest extends \PHPUnit_Framework_TestCase
 {
-    public function testGitHubEnterprise()
+    public function testCanGetGithubRepoName()
+    {
+        $api = new Github(
+            'git@github.com:producerphp/producer.producer.git',
+            'api.github.com',
+            'username',
+            'token'
+        );
+
+        $this->assertEquals('producerphp/producer.producer', $api->getRepoName());
+    }
+
+    public function testCanGetGitHubEnterpriseRepoName()
     {
         $api = new Github(
             'git@example.org:producerphp/producer.producer.git',

--- a/tests/Api/GitHubTest.php
+++ b/tests/Api/GitHubTest.php
@@ -5,27 +5,30 @@ use Producer\Api\Github;
 
 class GitHubTest extends \PHPUnit_Framework_TestCase
 {
-    public function testCanGetGithubRepoName()
+    /**
+     * @dataProvider remoteProvider
+     */
+    public function testRepoNameCanBeDerivedFromRemote($remote, $hostname, $repoName)
     {
         $api = new Github(
-            'git@github.com:producerphp/producer.producer.git',
-            'api.github.com',
+            $remote,
+            $hostname,
             'username',
             'token'
         );
 
-        $this->assertEquals('producerphp/producer.producer', $api->getRepoName());
+        $this->assertEquals($repoName, $api->getRepoName());
     }
 
-    public function testCanGetGitHubEnterpriseRepoName()
-    {
-        $api = new Github(
-            'git@example.org:producerphp/producer.producer.git',
-            'example.org',
-            'username',
-            'token'
-        );
-
-        $this->assertEquals('producerphp/producer.producer', $api->getRepoName());
+    public function remoteProvider()
+    {   
+        return [
+            ['git@github.com:user/repo.git', 'api.github.com', 'user/repo'],
+            ['http://github.com/user/repo.git', 'api.github.com', 'user/repo'],
+            ['https://github.com/user/repo.git', 'api.github.com', 'user/repo'],
+            ['git@example.org:user/repo.git', 'example.org', 'user/repo'],
+            ['http://example.org/user/repo.git', 'example.org', 'user/repo'],
+            ['https://example.org/user/repo.git', 'example.org', 'user/repo'],
+        ];
     }
 }

--- a/tests/Api/GitlabTest.php
+++ b/tests/Api/GitlabTest.php
@@ -5,25 +5,29 @@ use Producer\Api\Gitlab;
 
 class GitlabTest extends \PHPUnit_Framework_TestCase
 {
-    public function testCanGetGitlabRepoName()
+    /**
+     * @dataProvider remoteProvider
+     */
+    public function testRepoNameCanBeDerivedFromRemote($remote, $hostname, $repoName)
     {
         $api = new Gitlab(
-            'git@gitlab.com:producerphp/producer.producer.git',
-            'gitlab.com',
+            $remote,
+            $hostname,
             'token'
         );
 
-        $this->assertEquals('producerphp/producer.producer', $api->getRepoName());
+        $this->assertEquals($repoName, $api->getRepoName());
     }
 
-    public function testCanGetGitlabSelfHostedRepoName()
-    {
-        $api = new Gitlab(
-            'git@example.org:producerphp/producer.producer.git',
-            'example.org',
-            'token'
-        );
-
-        $this->assertEquals('producerphp/producer.producer', $api->getRepoName());
+    public function remoteProvider()
+    {   
+        return [
+            ['git@gitlab.com:user/repo.git', 'gitlab.com', 'user/repo'],
+            ['http://gitlab.com/user/repo.git', 'gitlab.com', 'user/repo'],
+            ['https://gitlab.com/user/repo.git', 'gitlab.com', 'user/repo'],
+            ['git@example.org:user/repo.git', 'example.org', 'user/repo'],
+            ['http://example.org/user/repo.git', 'example.org', 'user/repo'],
+            ['https://example.org/user/repo.git', 'example.org', 'user/repo'],
+        ];
     }
 }

--- a/tests/Api/GitlabTest.php
+++ b/tests/Api/GitlabTest.php
@@ -1,0 +1,29 @@
+<?php
+namespace Producer;
+
+use Producer\Api\Gitlab;
+
+class GitlabTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanGetGitlabRepoName()
+    {
+        $api = new Gitlab(
+            'git@gitlab.com:producerphp/producer.producer.git',
+            'gitlab.com',
+            'token'
+        );
+
+        $this->assertEquals('producerphp/producer.producer', $api->getRepoName());
+    }
+
+    public function testCanGetGitlabSelfHostedRepoName()
+    {
+        $api = new Gitlab(
+            'git@example.org:producerphp/producer.producer.git',
+            'example.org',
+            'token'
+        );
+
+        $this->assertEquals('producerphp/producer.producer', $api->getRepoName());
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -37,6 +37,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'github_hostname' => 'api.github.com',
             'github_token' => null,
             'github_username' => null,
+            'gitlab_hostname' => 'gitlab.com',
             'gitlab_token' => 'foobarbazdibzimgir',
             'package' => '',
             'commands' => [
@@ -57,7 +58,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
 
-    public function testGitHubBaseURLOverride()
+    public function testGitHubHostOverride()
     {
         $homefs = $this->mockFsio([
             'github_hostname' => 'example.org',
@@ -74,7 +75,45 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'github_hostname' => 'example.org',
             'github_token' => 'bar',
             'github_username' => 'foo',
+            'gitlab_hostname' => 'gitlab.com',
             'gitlab_token' => null,
+            'package' => '',
+            'commands' => [
+                'phpdoc' => 'phpdoc',
+                'phpunit' => 'phpunit',
+            ],
+            'files' => [
+                'changes' => 'CHANGES.md',
+                'contributing' => 'CONTRIBUTING.md',
+                'license' => 'LICENSE.md',
+                'phpunit' => 'phpunit.xml.dist',
+                'readme' => 'README.md',
+            ],
+        ];
+
+        $actual = $config->getAll();
+
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testGitlabHostOverride()
+    {
+        $homefs = $this->mockFsio([
+            'gitlab_hostname' => 'example.org',
+            'gitlab_token' => 'bar',
+        ]);
+        $repofs = $this->mockFsio([], false);
+
+        $config = new Config($homefs, $repofs);
+
+        $expect = [
+            'bitbucket_password' => null,
+            'bitbucket_username' => null,
+            'github_hostname' => 'api.github.com',
+            'github_token' => null,
+            'github_username' => null,
+            'gitlab_hostname' => 'example.org',
+            'gitlab_token' => 'bar',
             'package' => '',
             'commands' => [
                 'phpdoc' => 'phpdoc',
@@ -115,6 +154,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'github_hostname' => 'api.github.com',
             'github_token' => null,
             'github_username' => null,
+            'gitlab_hostname' => 'gitlab.com',
             'gitlab_token' => 'foobarbazdibzimgir',
             'package' => 'Foo.Bar',
             'commands' => [

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -34,7 +34,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $expect = [
             'bitbucket_password' => null,
             'bitbucket_username' => null,
-            'github_baseurl' => 'https://api.github.com',
+            'github_hostname' => 'api.github.com',
             'github_token' => null,
             'github_username' => null,
             'gitlab_token' => 'foobarbazdibzimgir',
@@ -60,8 +60,9 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testGitHubBaseURLOverride()
     {
         $homefs = $this->mockFsio([
-            'github_baseurl' => 'https://hostname/api/v3',
-            'github_token' => 'foo',
+            'github_hostname' => 'example.org',
+            'github_username' => 'foo',
+            'github_token' => 'bar',
         ]);
         $repofs = $this->mockFsio([], false);
 
@@ -70,9 +71,9 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $expect = [
             'bitbucket_password' => null,
             'bitbucket_username' => null,
-            'github_baseurl' => 'https://hostname/api/v3',
-            'github_token' => 'foo',
-            'github_username' => null,
+            'github_hostname' => 'example.org',
+            'github_token' => 'bar',
+            'github_username' => 'foo',
             'gitlab_token' => null,
             'package' => '',
             'commands' => [
@@ -111,7 +112,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $expect = [
             'bitbucket_password' => null,
             'bitbucket_username' => null,
-            'github_baseurl' => 'https://api.github.com',
+            'github_hostname' => 'api.github.com',
             'github_token' => null,
             'github_username' => null,
             'gitlab_token' => 'foobarbazdibzimgir',

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -34,6 +34,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $expect = [
             'bitbucket_password' => null,
             'bitbucket_username' => null,
+            'github_baseurl' => 'https://api.github.com',
             'github_token' => null,
             'github_username' => null,
             'gitlab_token' => 'foobarbazdibzimgir',
@@ -41,6 +42,42 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'commands' => [
                 'phpdoc' => 'phpdoc',
                 'phpunit' => '/path/to/phpunit',
+            ],
+            'files' => [
+                'changes' => 'CHANGES.md',
+                'contributing' => 'CONTRIBUTING.md',
+                'license' => 'LICENSE.md',
+                'phpunit' => 'phpunit.xml.dist',
+                'readme' => 'README.md',
+            ],
+        ];
+
+        $actual = $config->getAll();
+
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testGitHubBaseURLOverride()
+    {
+        $homefs = $this->mockFsio([
+            'github_baseurl' => 'https://hostname/api/v3',
+            'github_token' => 'foo',
+        ]);
+        $repofs = $this->mockFsio([], false);
+
+        $config = new Config($homefs, $repofs);
+
+        $expect = [
+            'bitbucket_password' => null,
+            'bitbucket_username' => null,
+            'github_baseurl' => 'https://hostname/api/v3',
+            'github_token' => 'foo',
+            'github_username' => null,
+            'gitlab_token' => null,
+            'package' => '',
+            'commands' => [
+                'phpdoc' => 'phpdoc',
+                'phpunit' => 'phpunit',
             ],
             'files' => [
                 'changes' => 'CHANGES.md',
@@ -74,6 +111,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $expect = [
             'bitbucket_password' => null,
             'bitbucket_username' => null,
+            'github_baseurl' => 'https://api.github.com',
             'github_token' => null,
             'github_username' => null,
             'gitlab_token' => 'foobarbazdibzimgir',

--- a/tests/ProducerContainerTest.php
+++ b/tests/ProducerContainerTest.php
@@ -11,7 +11,7 @@ class ProducerContainerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider githubProvider
      */
-    public function testThatItReturnsAppropriateApiImplementationForGithub($host, $origin)
+    public function testThatItReturnsAppropriateApiImplementationForGithub($host, $origin, $repoName)
     {
         $container = new ProducerContainer($_SERVER['HOME'], getcwd(), STDOUT, STDERR);
 
@@ -30,13 +30,14 @@ class ProducerContainerTest extends \PHPUnit_Framework_TestCase
         $api = $newApi->invokeArgs($container, [$origin, $config]);
         
         $this->assertInstanceOf(Github::class, $api);
+        $this->assertEquals($repoName, $api->getRepoName());
     }
 
     public function githubProvider()
     {
         return [
-            ['github.enterprise.com', 'git@github.enterprise.com:producer/producer.git'],
-            ['api.github.com', 'git@github.com:producer/producer.git'],
+            ['github.enterprise.com', 'git@github.enterprise.com:producer/producer.git', 'producer/producer'],
+            ['api.github.com', 'git@github.com:producer/producer.git', 'producer/producer'],
         ];
     }
 

--- a/tests/ProducerContainerTest.php
+++ b/tests/ProducerContainerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Producer;
+
+use Producer\Api\Github;
+use ReflectionClass;
+
+class ProducerContainerTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @dataProvider githubProvider
+     */
+    public function testThatItReturnsAppropriateApiImplementationForGithub($host, $origin)
+    {
+        $container = new ProducerContainer($_SERVER['HOME'], getcwd(), STDOUT, STDERR);
+
+        // Unlock ProducerContainer#newApi...
+        $reflector = new ReflectionClass($container);
+        $newApi = $reflector->getMethod('newApi');
+        $newApi->setAccessible(true);
+
+        $config = $this->mockConfig([
+            'github_hostname' => $host,
+            'github_username' => 'producer',
+            'github_token' => 'token',
+        ]);
+
+        // $container->newApi($origin, $config) : ApiInterfaces
+        $api = $newApi->invokeArgs($container, [$origin, $config]);
+        
+        $this->assertInstanceOf(Github::class, $api);
+    }
+
+    public function githubProvider()
+    {
+        return [
+            ['github.enterprise.com', 'git@github.enterprise.com:producer/producer.git'],
+            ['api.github.com', 'git@github.com:producer/producer.git'],
+        ];
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function mockConfig($data)
+    {
+        $config = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        foreach ($data as $arg => $return) {
+            $valueMap[] = [$arg, $return];
+        }
+
+        $config->expects($this->any())
+            ->method('get')
+            ->will($this->returnValueMap($valueMap));
+
+        return $config;
+    }
+
+}


### PR DESCRIPTION
This introduces support for releasing packages on GitHub Enterprise. I have tested this at NC State and the package functions as reported through a new configuration option, `github_hostname`. There are currently no integration tests that I could find that test collaboration between `Api\GitHub` and `Http`. I can add a few to demonstrate that based on configuration, HTTP base URL is adjusted appropriately. Let me know if this should be done.

A new configuration option, `github_hostname`, is added to allow GitHub Enterprise users to specify their appliance hostname. The `Github` `AbstractApi` is responsible for taking that hostname and appending `/api/v3` if the hostname does not contain `github.com`. This is documented at https://developer.github.com/v3/enterprise. This feature is **forward compatible** (double-check please) for current GitHub.com users. If unspecified, a default of `api.github.com` is populated in config rather than `null`. **_This_** is what feels awkward to me, but I think it's a matter of opinion since at runtime the API chosen is based on project `origin` and it is completely reasonable for someone to have a user config that uses many git hosting providers, I imagine. I leave whether "this is awkward" or not to the maintainers!

A `private` method was created to set repository name on `Api\Github` based on origin. This is called in constructor. The implementation of this was changed to remove (what I saw) as superfluous code. I implemented a test for `Api\Github` that seems to correctly identify the repository name on "dot com" and Enterprise. If there are edge-cases that have been regressed by this change, I'll revert removals I've made. `git blame` on the class did not reveal any special circumstances / reasons for which this logic was chosen. Looks to just be part of the first "minimalist implementation".

Anywho, I look forward to review.

Implementation is open for adjustment, obviously.

---

Here's some sample output from our install at NC State University; pulling issues for some arbitrary repository:

```
[vagrant@local restful-misery]$ ../producer.producer/bin/producer issues
mdwheele/restful-misery

    7. GUI Workflow for Adding Shortcodes
        https://github.ncsu.edu/mdwheele/restful-misery/issues/7

    13. Using __invoke, or __construct for the wordpress classes instead of a doTheNeedful() type approach
        https://github.ncsu.edu/mdwheele/restful-misery/issues/13

    15. Auth
        https://github.ncsu.edu/mdwheele/restful-misery/issues/15

    16. Additional p and br tags added before table
        https://github.ncsu.edu/mdwheele/restful-misery/issues/16
```
