### PR TITLE
When $file false, message shows blank file name.

### DIFF
--- a/src/Repo/AbstractRepo.php
+++ b/src/Repo/AbstractRepo.php
@@ -203,7 +203,7 @@ abstract class AbstractRepo implements RepoInterface
                 }
             }
             if (! $file) {
-                throw new Exception("The file {$file} is missing.");
+                throw new Exception("The file {$supportFile} is missing.");
             }
             if (trim($this->fsio->get($file)) === '') {
                 throw new Exception("The file {$file} is empty.");


### PR DESCRIPTION
If a file is missing, the exception message tries to display the blank value of `$file` rather than the file it was looking for.  I think this will fix the problem.